### PR TITLE
fix spelling of resource name

### DIFF
--- a/TooLong/Properties/Resources.Designer.cs
+++ b/TooLong/Properties/Resources.Designer.cs
@@ -135,9 +135,9 @@ namespace TooLong.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Access Denied.
         /// </summary>
-        public static string ErrorAcessDenied {
+        public static string ErrorAccessDenied {
             get {
-                return ResourceManager.GetString("ErrorAcessDenied", resourceCulture);
+                return ResourceManager.GetString("ErrorAccessDenied", resourceCulture);
             }
         }
         

--- a/TooLong/Properties/Resources.resx
+++ b/TooLong/Properties/Resources.resx
@@ -141,7 +141,7 @@
   <data name="Error" xml:space="preserve">
     <value>Error</value>
   </data>
-  <data name="ErrorAcessDenied" xml:space="preserve">
+  <data name="ErrorAccessDenied" xml:space="preserve">
     <value>Access Denied</value>
   </data>
   <data name="ErrorEmptyPath" xml:space="preserve">


### PR DESCRIPTION
Hello,

I noticed that Resources.ErrorAccessDenied is misspelled in Properties\Resources.resx.

Regards,

David Bremner